### PR TITLE
[SF-1135] fix flatten error again

### DIFF
--- a/compressor/base.py
+++ b/compressor/base.py
@@ -374,7 +374,10 @@ class Compressor(object):
             # NOTE the next line avoids https://github.com/django-compressor/django-compressor/issues/706
             # by ensuring any object in self.context.dicts is "pre-flattened" before attempting to flatten
             # the overall context.
-            self.context.dicts = list(map(lambda d: d.flatten() if hasattr(d, 'flatten') else d, self.context.dicts))
+            self.context.dicts = [
+               d.flatten() if hasattr(d, 'flatten') else d
+               for d in self.context.dicts
+            ]
             final_context = self.context.flatten()
         else:
             final_context = self.context

--- a/compressor/base.py
+++ b/compressor/base.py
@@ -371,6 +371,10 @@ class Compressor(object):
 
         if hasattr(self.context, 'flatten'):
             # Passing Contexts to Template.render is deprecated since Django 1.8.
+            # NOTE the next line avoids https://github.com/django-compressor/django-compressor/issues/706
+            # by ensuring any object in self.context.dicts is "pre-flattened" before attempting to flatten
+            # the overall context.
+            self.context.dicts = list(map(lambda d: d.flatten() if hasattr(d, 'flatten') else d, self.context.dicts))
             final_context = self.context.flatten()
         else:
             final_context = self.context


### PR DESCRIPTION
https://github.com/nasft/django-compressor/commit/2496124d9449666f5df1e05e1a781929e20616b0 was the version we had been using for the 1.11 upgrade, but it seems that will remove dicts from the list when they don't have a flatten method, which seems wrong. 

So here rather than trying the overall flatten and falling back to creating a new list of "dicts" by calling flatten method on any item that has it, this version ensure that the list of context dicts used for the overall flatten are pre-flattened by calling flatten on any that have this method before attempting the overall flatten.